### PR TITLE
Add Semrush incremental traffic estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # semrush-traffic
-semrush-traffic
+
+Outil pour estimer le trafic incrémental à partir d'un export Semrush.
+
+Une version web est fournie pour un hébergement facile (par exemple sur Netlify).
+
+## Application web
+
+1. Ouvrir `index.html` dans un navigateur.
+2. Choisir le fichier Excel exporté depuis Semrush.
+3. Indiquer le gain de positions et le multiplicateur de CTR.
+4. Cliquer sur **Estimate** pour afficher le trafic incrémental par cocon sémantique et un graphique.
+
+Le site peut être déployé tel quel sur Netlify en tant que site statique.
+
+## Utilisation
+
+```bash
+python traffic_estimator.py mondialrelay.fr-organic.Positions-fr-20250809-2025-08-10T17_40_01Z.xlsx \
+    --improvement 2 \
+    --ctr-multiplier 1.2
+```
+
+* `--improvement` : nombre de positions gagnées pour chaque mot-clé.
+* `--ctr-multiplier` : facteur appliqué au CTR après optimisation (ex : 1.2 = +20%).
+
+Le script génère :
+
+* `traffic_estimates.csv` : détail des estimations pour chaque mot-clé.
+* `incremental_traffic.png` : graphique du trafic incrémental par cocon sémantique.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Semrush Incremental Traffic Estimator</title>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <h1>Semrush Incremental Traffic Estimator</h1>
+  <input type="file" id="fileInput" accept=".xlsx" />
+  <label>
+    Position improvement:
+    <input type="number" id="improvement" value="1" min="0" />
+  </label>
+  <label>
+    CTR multiplier:
+    <input type="number" id="ctrMultiplier" value="1" step="0.1" min="0" />
+  </label>
+  <button id="runBtn">Estimate</button>
+  <div id="results"></div>
+  <canvas id="chart" width="800" height="400"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,101 @@
+const CTR_CURVE = {
+  1: 0.30,
+  2: 0.15,
+  3: 0.10,
+  4: 0.07,
+  5: 0.05,
+  6: 0.04,
+  7: 0.03,
+  8: 0.02,
+  9: 0.015,
+ 10: 0.01
+};
+
+function extractCocon(url) {
+  try {
+    const u = new URL(url);
+    const path = u.pathname.replace(/^\/+/g, '').replace(/\/+$/g, '');
+    if (!path) return u.hostname;
+    return path.split('/')[0];
+  } catch (e) {
+    return 'unknown';
+  }
+}
+
+function estimate(data, improvement, multiplier) {
+  const results = {};
+  data.forEach(row => {
+    const sv = Number(row['Search Volume']) || 0;
+    const pos = Number(row['Position']) || 100;
+    const currentCtr = CTR_CURVE[pos] || 0.005;
+    const currentTraffic = sv * currentCtr;
+    const newPos = Math.max(1, pos - improvement);
+    const newCtr = (CTR_CURVE[newPos] || 0.005) * multiplier;
+    const newTraffic = sv * newCtr;
+    const incremental = newTraffic - currentTraffic;
+    const cocon = extractCocon(row['URL']);
+    results[cocon] = (results[cocon] || 0) + incremental;
+  });
+  return results;
+}
+
+function render(results) {
+  const container = document.getElementById('results');
+  container.innerHTML = '';
+  const entries = Object.entries(results).sort((a,b) => b[1] - a[1]);
+  const table = document.createElement('table');
+  const header = document.createElement('tr');
+  header.innerHTML = '<th>Cocon</th><th>Incremental Traffic</th>';
+  table.appendChild(header);
+  entries.forEach(([cocon, value]) => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${cocon}</td><td>${value.toFixed(2)}</td>`;
+    table.appendChild(row);
+  });
+  container.appendChild(table);
+
+  const ctx = document.getElementById('chart').getContext('2d');
+  if (window.chartInstance) {
+    window.chartInstance.destroy();
+  }
+  window.chartInstance = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: entries.map(e => e[0]),
+      datasets: [{
+        label: 'Incremental Traffic',
+        data: entries.map(e => e[1]),
+        backgroundColor: 'rgba(54, 162, 235, 0.5)'
+      }]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('runBtn').addEventListener('click', () => {
+    const fileInput = document.getElementById('fileInput');
+    if (!fileInput.files.length) {
+      alert('Please select an Excel file');
+      return;
+    }
+    const improvement = Number(document.getElementById('improvement').value) || 0;
+    const multiplier = Number(document.getElementById('ctrMultiplier').value) || 1;
+    const file = fileInput.files[0];
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const data = new Uint8Array(e.target.result);
+      const workbook = XLSX.read(data, { type: 'array' });
+      const firstSheet = workbook.Sheets[workbook.SheetNames[0]];
+      const json = XLSX.utils.sheet_to_json(firstSheet);
+      const results = estimate(json, improvement, multiplier);
+      render(results);
+    };
+    reader.readAsArrayBuffer(file);
+  });
+});

--- a/traffic_estimator.py
+++ b/traffic_estimator.py
@@ -1,0 +1,96 @@
+import argparse
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+from urllib.parse import urlparse
+
+# Default CTR curve for positions 1-10 (approximate values)
+DEFAULT_CTR = {
+    1: 0.30,
+    2: 0.15,
+    3: 0.10,
+    4: 0.07,
+    5: 0.05,
+    6: 0.04,
+    7: 0.03,
+    8: 0.02,
+    9: 0.015,
+    10: 0.01
+}
+
+
+def extract_cocon(url: str) -> str:
+    """Extract a simple semantic group (cocon) from the URL.
+
+    This takes the first path segment after the domain. If no path exists,
+    the domain itself is returned.
+    """
+    if not isinstance(url, str) or not url:
+        return "unknown"
+    try:
+        parsed = urlparse(url)
+        path = parsed.path.strip("/")
+        if not path:
+            return parsed.netloc
+        return path.split("/")[0]
+    except Exception:
+        return "unknown"
+
+
+def estimate_incremental_traffic(df: pd.DataFrame, improvement: int, ctr_multiplier: float) -> pd.DataFrame:
+    """Estimate new traffic and incremental traffic after position & CTR improvements."""
+    df = df.copy()
+    df["Search Volume"] = df["Search Volume"].fillna(0)
+    df["Position"] = df["Position"].fillna(100)
+
+    # Current estimated traffic using CTR curve
+    df["current_ctr"] = df["Position"].map(DEFAULT_CTR).fillna(0.005)
+    df["current_estimated_traffic"] = df["Search Volume"] * df["current_ctr"]
+
+    # Apply position improvement
+    df["new_position"] = (df["Position"] - improvement).clip(lower=1)
+    df["new_ctr"] = df["new_position"].map(DEFAULT_CTR).fillna(0.005)
+    df["new_ctr"] *= ctr_multiplier
+    df["new_estimated_traffic"] = df["Search Volume"] * df["new_ctr"]
+
+    df["incremental_traffic"] = df["new_estimated_traffic"] - df["current_estimated_traffic"]
+
+    # Add cocon column
+    df["Cocon"] = df["URL"].apply(extract_cocon)
+    return df
+
+
+def plot_incremental_by_cocon(df: pd.DataFrame, output: str):
+    grouped = df.groupby("Cocon")["incremental_traffic"].sum().sort_values(ascending=False)
+    plt.figure(figsize=(10, 6))
+    grouped.plot(kind="bar")
+    plt.ylabel("Incremental Traffic")
+    plt.title("Incremental Traffic by Semantic Cocon")
+    plt.tight_layout()
+    plt.savefig(output)
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Estimate incremental traffic from Semrush export.")
+    parser.add_argument("excel", help="Path to Semrush Excel export")
+    parser.add_argument("--improvement", type=int, default=1, help="Number of positions gained for each keyword")
+    parser.add_argument("--ctr-multiplier", type=float, default=1.0, help="Multiplier applied to CTR after optimization")
+    parser.add_argument("--chart", default="incremental_traffic.png", help="Path to save bar chart of incremental traffic")
+
+    args = parser.parse_args()
+
+    df = pd.read_excel(args.excel)
+    result = estimate_incremental_traffic(df, args.improvement, args.ctr_multiplier)
+
+    plot_incremental_by_cocon(result, args.chart)
+
+    summary = result.groupby("Cocon")["incremental_traffic"].sum().reset_index()
+    print(summary.sort_values("incremental_traffic", ascending=False))
+    result.to_csv("traffic_estimates.csv", index=False)
+    print("Detailed estimates saved to traffic_estimates.csv")
+    print(f"Chart saved to {args.chart}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add web-based Semrush traffic estimator for Netlify deployment
- Document browser usage alongside existing Python CLI tool

## Testing
- `python -m py_compile traffic_estimator.py`
- `python traffic_estimator.py mondialrelay.fr-organic.Positions-fr-20250809-2025-08-10T17_40_01Z.xlsx --improvement 2 --ctr-multiplier 1.2`

------
https://chatgpt.com/codex/tasks/task_e_6898e13437308324af3848a11ebb2c3d